### PR TITLE
Use request body limit from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ docker run --name html2pdf --detach -p=<port>:3000 \
 
 Stop with: `docker stop html2pdf`
 
+## Docker Environment Variables
+
+| Name       | Description                                                                                                               | Default Value |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| BODY_LIMIT | Maximum request body size. Passed on to [body-parser](https://github.com/expressjs/body-parser#limit) and `express.json`. | `1mb`         |
+
 ## Use it
 
 The webserver listens on the port (specified in the [Run it](#run-it) section) and exposes two endpoints:

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,10 @@ const tmp = require('tmp');
 const app = express();
 const port = 3000;
 
-app.use(express.json({ limit: '1mb' }));
-app.use(bodyParser.text({ type: 'text/html' }));
+const limit = process.env.BODY_LIMIT || '1mb';
+
+app.use(express.json({ limit }));
+app.use(bodyParser.text({ type: 'text/html', limit }));
 app.use(booleanParser());
 app.use(numberParser());
 


### PR DESCRIPTION
Hey, cool project 🙌 I am considering using it for a client in production, it works pretty well from my testing for now! The thing is, the PDFs that I'm rendering are pretty complex - easily above the `100kb` limit for a single doc.

I added the possibility to pass on the express body limit from env (`docker run -e ...`) - that would solve my issue.